### PR TITLE
monolog 1.15.0 mkdir fix

### DIFF
--- a/Log/MonologWriter.php
+++ b/Log/MonologWriter.php
@@ -97,18 +97,23 @@ class MonologWriter
 	 * (array) Array of monolog processors - anonymous functions
 	 *
 	 * @param   array $settings
+	 * @param bool $merge
 	 * @return  void
 	 */
-	public function __construct($settings = array())
+	public function __construct($settings = array(), $merge = true)
 	{
 		//Merge user settings
-		$this->settings = array_merge(array(
-			'name' => 'SlimMonoLogger',
-			'handlers' => array(
-	        	new \Monolog\Handler\StreamHandler('./logs/'.date('y-m-d').'.log'),
-	        ),
-	        'processors' => array(),
-		), $settings);
+	        if ($merge) {
+	            $this->settings = array_merge(array(
+	                'name' => 'SlimMonoLogger',
+	                'handlers' => array(
+	                    new \Monolog\Handler\StreamHandler('./logs/'.date('y-m-d').'.log'),
+	                ),
+	                'processors' => array(),
+	            ), $settings);
+	        } else {
+	            $this->settings = $settings;
+	        }
 	}
 
 	/**


### PR DESCRIPTION
Monolog, as of 1.15.0, tries to create a dir on every log action and raises an exception.
Slim-Monolog creates an unused monolog instance with an invalid log dir in its constructor.

https://github.com/Flynsarmy/Slim-Monolog/issues/8